### PR TITLE
fix for #47

### DIFF
--- a/client/src/active/ActiveQuestion.jsx
+++ b/client/src/active/ActiveQuestion.jsx
@@ -3,7 +3,7 @@ import './ActiveGame.css';
 
 import {Breadcrumb, Card, Tooltip} from 'antd';
 import {EditOutlined, InfoCircleOutlined, PlaySquareOutlined} from '@ant-design/icons';
-import FormattedQuestion from "../question/FormattedQuestion"
+import FormattedQuestion, {MemoFormattedQuestion} from "../question/FormattedQuestion"
 import HotEditQuestion from "./HotEditQuestion";
 import HotEditRoundName from "./HotEditRoundName";
 
@@ -74,9 +74,9 @@ class ActiveQuestion extends React.Component {
 
 
                 <div className="active-question-box">
-                    <FormattedQuestion question={this.props.question}
-                                       answer={this.props.answer} max_width={350}
-                                       scored={this.props.scored}
+                    <MemoFormattedQuestion question={this.props.question}
+                                           answer={this.props.answer} max_width={350}
+                                           scored={this.props.scored}
                     />
                     {editQuestionModal}
                 </div>

--- a/client/src/question/FormattedQuestion.jsx
+++ b/client/src/question/FormattedQuestion.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 
 import ReactMarkdown from "react-markdown";
 import remarkGfm from 'remark-gfm'
@@ -84,3 +84,5 @@ function asCode(rawText) {
         </div>
     })
 }
+
+export const MemoFormattedQuestion = memo(FormattedQuestion)


### PR DESCRIPTION
Fix issue #47  where audio / image viewer would reset when a new answer comes in

Use `React.memo` on `FormattedQuestion` component in `ActiveQuestion.jsx`
- This will only re-render when the question or answer has changed, 
- E.g. if you hot edit a question it will still reset the view, but that is expected as a force re-render is correct
- Also will reset when the admin scores the question, but that should be fine too