### PR TITLE
possible fix for client wager issue (#6)

### DIFF
--- a/client/src/active/ActiveGame.jsx
+++ b/client/src/active/ActiveGame.jsx
@@ -32,14 +32,13 @@ class ActiveGame extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.session_state !== prevProps.session_state) {
-            this.get_current_question()
-            this.get_round()
+            this.get_current_question().then(() => this.get_round())
         }
     }
 
     get_round = () => {
         let url = "/gameplay/session/" + this.props.session_id + "/current-round"
-        fetch(url).then(response => response.json())
+        return fetch(url).then(response => response.json())
             .then(r => {
                 console.log(r)
                 this.setState({
@@ -53,7 +52,7 @@ class ActiveGame extends React.Component {
 
     get_current_question = () => {
         let url = "/gameplay/session/" + this.props.session_id + "/current-question?player_id=" + this.props.player_id
-        fetch(url).then(response => response.json())
+        return fetch(url).then(response => response.json())
             .then(q => {
                 console.log(q)
                 this.setState({

--- a/client/src/answer/WagerManager.jsx
+++ b/client/src/answer/WagerManager.jsx
@@ -18,11 +18,10 @@ class WagerManager extends React.Component {
 
     componentDidUpdate(prevProps) {
         printDiffs(this.props, prevProps)
-        if (this.props.question_id !== prevProps.question_id) {
-            this.get_available_wagers()
-        }
-        if (this.props.round_id !== prevProps.round_id) {
-            this.get_available_wagers()
+        if (this.props.question_id !== prevProps.question_id || this.props.round_id !== prevProps.round_id) {
+            this.setState({ available_wagers: [], avail_count: {} }, () => {
+                this.get_available_wagers()
+            })
         }
     }
 
@@ -54,6 +53,9 @@ class WagerManager extends React.Component {
                 .then((data) => {
                     console.log(data)
                     this.set_available_wagers(data)
+                })
+                .catch((err) => {
+                    console.error("Failed to fetch available wagers:", err)
                 })
         }
     }

--- a/client/src/answer/WagerManager.jsx
+++ b/client/src/answer/WagerManager.jsx
@@ -10,6 +10,7 @@ class WagerManager extends React.Component {
         this.state = {
             available_wagers: [],
         }
+        this.fetchCounter = 0
     }
 
     componentDidMount() {
@@ -19,9 +20,7 @@ class WagerManager extends React.Component {
     componentDidUpdate(prevProps) {
         printDiffs(this.props, prevProps)
         if (this.props.question_id !== prevProps.question_id || this.props.round_id !== prevProps.round_id) {
-            this.setState({ available_wagers: [], avail_count: {} }, () => {
-                this.get_available_wagers()
-            })
+            this.get_available_wagers()
         }
     }
 
@@ -44,6 +43,9 @@ class WagerManager extends React.Component {
     get_available_wagers = () => {
         //get available wagers and truncate duplicates
         if (this.props.round_id !== "" && this.props.question_id !== "") {
+            this.fetchCounter += 1
+            const currentFetch = this.fetchCounter
+
             let url = "/gameplay/session/" + this.props.session_id + "/wagers"
             url += "?player_id=" + this.props.player_id
             url += "&round_id=" + this.props.round_id
@@ -52,7 +54,10 @@ class WagerManager extends React.Component {
             sendData(url, "GET")
                 .then((data) => {
                     console.log(data)
-                    this.set_available_wagers(data)
+                    // Only apply if this is still the latest request
+                    if (currentFetch === this.fetchCounter) {
+                        this.set_available_wagers(data)
+                    }
                 })
                 .catch((err) => {
                     console.error("Failed to fetch available wagers:", err)


### PR DESCRIPTION
Fixes stale wager data appearing when advancing to a new round. The bug occurred because `WagerManager` made multiple concurrent API calls to fetch available wagers in response to `round_id` and `question_id` prop changes, and slower responses from earlier requests could overwrite the correct, more recent data.

## Problem

When the game admin advances to a new round, `ActiveGame` fires two concurrent `fetch()` calls (`get_current_question()` and `get_round()`) in `componentDidUpdate`. Each resolves independently and triggers `WagerManager.componentDidUpdate`, which fires its own API call to `/wagers`.

Because both the parent's fetches and the child's fetches are concurrent, multiple in-flight requests to `/wagers` can exist simultaneously. If an earlier request (e.g., for the wrong round/question combo) resolves after a later correct one, stale wager data overwrites the correct state — leaving the player with no available wagers to select.

Refreshing the page worked because it mounted fresh with correct props, bypassing the race entirely.

## Changes

- **`client/src/active/ActiveGame.jsx`**: Sequence `get_current_question()` → `get_round()` so `active_question` is set before `active_round`, reducing `WagerManager` to a single fetch per round transition. Both methods now return their Promises to enable chaining.

- **`client/src/answer/WagerManager.jsx`**: Add a `fetchCounter` that increments with each fetch. Responses are only applied if their captured counter matches the current counter, discarding stale responses from superseded requests.